### PR TITLE
feat: Upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:
-          version: v1.59.1
+          version: v2.4.0
   build:
     name: build
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+version: "2"
+
+linters:
+  default: standard
+
+run:
+  timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.51.2
+    rev: v2.4.0
     hooks:
       - id: golangci-lint

--- a/cmd/brew.go
+++ b/cmd/brew.go
@@ -17,7 +17,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/user"
 	"path"
@@ -297,7 +297,7 @@ func containsFileType(files []os.FileInfo, fileType FileType) bool {
 }
 
 func bodyToString(res *jira.Response) string {
-	bytes, _ := ioutil.ReadAll(res.Body)
+	bytes, _ := io.ReadAll(res.Body)
 	bodyStr := string(bytes)
 	return bodyStr
 }


### PR DESCRIPTION
Upgrades golangci-lint to v2.4.0 and the corresponding GitHub action to v8.

This change also creates a new .golangci.yml configuration file with a v2-compatible format.